### PR TITLE
Fix `tickIterator` going out of bounds

### DIFF
--- a/src/main/java/com/eventsapi/EventsAPIPlugin.java
+++ b/src/main/java/com/eventsapi/EventsAPIPlugin.java
@@ -86,7 +86,7 @@ public class EventsAPIPlugin extends Plugin
 		this.detectQuestEvents();
 		this.detectBankWindowClosing();
 
-		if (tickIterator == this.config.tickDelay()) {
+		if (tickIterator >= this.config.tickDelay()) {
 			this.createAndSendPlayerStatusNotification();
 			tickIterator = 0;
 		}


### PR DESCRIPTION
If the original `tickDelay` setting is set to 10 and is
changed to 5 while `tickIterator` is 7, `tickIterator` will
keep incrementing without ever reaching the part of the logic
that resets `tickIterator` back to 0

Fixes #4
