### PR TITLE
#6 Include username field in Login_State change

### DIFF
--- a/src/main/java/com/eventsapi/EventsAPIPlugin.java
+++ b/src/main/java/com/eventsapi/EventsAPIPlugin.java
@@ -107,7 +107,13 @@ public class EventsAPIPlugin extends Plugin
 	public void onGameStateChanged(GameStateChanged state){
 		if(state.getGameState() == GameState.LOGIN_SCREEN){
 			if(hasLoggedIn == true){
-				LoginNotification loggedOut = new LoginNotification(LOGIN_STATE.LOGGED_OUT);
+				String username = "";
+				Player tempPlayer = this.client.getLocalPlayer();
+				if(tempPlayer != null){
+					username = tempPlayer.getName();
+				}
+				LoginNotification loggedOut = new LoginNotification(username, LOGIN_STATE.LOGGED_OUT);
+				System.out.println(loggedOut);
 				messageHandler.sendEventNow(MESSAGE_EVENT.LOGIN, loggedOut);
 				this.hasLoggedIn = false;
 			}
@@ -118,7 +124,13 @@ public class EventsAPIPlugin extends Plugin
 
 		if(state.getGameState() == GameState.LOGGED_IN){
 			this.hasLoggedIn = true;
-			LoginNotification loggedIn = new LoginNotification((LOGIN_STATE.LOGGED_IN));
+			String username = "";
+			Player tempPlayer = this.client.getLocalPlayer();
+			if(tempPlayer != null){
+				username = tempPlayer.getName();
+			}
+			LoginNotification loggedIn = new LoginNotification(username, (LOGIN_STATE.LOGGED_IN));
+			System.out.println(loggedIn);
 			messageHandler.sendEventNow(MESSAGE_EVENT.LOGIN, loggedIn);
 		}
 	}

--- a/src/main/java/com/eventsapi/EventsAPIPlugin.java
+++ b/src/main/java/com/eventsapi/EventsAPIPlugin.java
@@ -112,8 +112,8 @@ public class EventsAPIPlugin extends Plugin
 				if(tempPlayer != null){
 					username = tempPlayer.getName();
 				}
+
 				LoginNotification loggedOut = new LoginNotification(username, LOGIN_STATE.LOGGED_OUT);
-				System.out.println(loggedOut);
 				messageHandler.sendEventNow(MESSAGE_EVENT.LOGIN, loggedOut);
 				this.hasLoggedIn = false;
 			}
@@ -124,13 +124,7 @@ public class EventsAPIPlugin extends Plugin
 
 		if(state.getGameState() == GameState.LOGGED_IN){
 			this.hasLoggedIn = true;
-			String username = "";
-			Player tempPlayer = this.client.getLocalPlayer();
-			if(tempPlayer != null){
-				username = tempPlayer.getName();
-			}
-			LoginNotification loggedIn = new LoginNotification(username, (LOGIN_STATE.LOGGED_IN));
-			System.out.println(loggedIn);
+			LoginNotification loggedIn = new LoginNotification("", (LOGIN_STATE.LOGGED_IN));
 			messageHandler.sendEventNow(MESSAGE_EVENT.LOGIN, loggedIn);
 		}
 	}

--- a/src/main/java/com/eventsapi/notifications/LoginNotification.java
+++ b/src/main/java/com/eventsapi/notifications/LoginNotification.java
@@ -9,9 +9,14 @@ import lombok.Setter;
 public class LoginNotification implements Sendable {
     private static final String API_ENDPOINT = Endpoint.LOGIN_NOTIFICATION;
 
-    public LoginNotification(LOGIN_STATE state){
+    public LoginNotification(String username, LOGIN_STATE state){
+        this.setUsername(username);
         this.setState(state);
     }
+
+    @Getter
+    @Setter
+    private String username;
 
     @Getter
     @Setter


### PR DESCRIPTION
Implementation for issue #6 - Had to include the clientThread as the username wasn't available at the point where the game state changed to logged_in.

`clientThread.InvokeLater()` seems to do the trick though.

Let me know if you have any thoughts! I saw your plugin on the hub and it perfectly aligned with something I've been trying to implement. 